### PR TITLE
Json table schema

### DIFF
--- a/src/export-menu.js
+++ b/src/export-menu.js
@@ -50,7 +50,7 @@ class ExportMenu extends React.Component {
       float: 'number',
       text: 'string'
     }
-    return fields.map((field) => {
+    const jtsFields = fields.map((field) => {
       const fieldType = typeMap[field.type] || field.type
       const jtsField = {
         name: field.machineName,
@@ -62,8 +62,9 @@ class ExportMenu extends React.Component {
       if (fieldType === 'string') {
         jtsField.constraints.maxLength = field.maxLength
       }
-      return JSON.stringify(jtsField, null, 2)
+      return jtsField
     })
+    return JSON.stringify({fields: jtsFields}, null, 2)
   }
 
   exportSql (client, fields) {

--- a/src/export-menu.js
+++ b/src/export-menu.js
@@ -1,31 +1,40 @@
 import React from 'react'
 import Knex from 'knex'
+import {partial} from 'lodash'
 
 export default React.createClass({
-  exportTypes: [
-    {value: 'mysql', label: 'MySQL'},
-    {value: 'mariadb', label: 'MariaDB'},
-    {value: 'postgres', label: 'Postgres'},
-    {value: 'oracle', label: 'Oracle'},
-    {value: 'sqlite3', label: 'SQLite3'}
-  ],
+  getExportTypes: function () {
+    return {
+      'MySQL': partial(this.exportSql, 'mysql'),
+      'MariaDB': partial(this.exportSql, 'mariadb'),
+      'Postgres': partial(this.exportSql, 'postgres'),
+      'Oracle': partial(this.exportSql, 'oracle'),
+      'SQLite3': partial(this.exportSql, 'sqlite3'),
+      'JSON Table Schema': this.exportJSONTableSchema
+    }
+  },
   getInitialState: function () {
     return {
-      exportType: 'mysql'
+      exportType: 'MySQL'
     }
   },
   render: function () {
-    const tableName = this.props.file.name ? this.props.file.name.split('.')[0] : 'table_name'
     const enabledFields = this.props.fields.filter((field) => field.enabled)
-    const exportResult = this.exportSql(tableName, enabledFields, this.state.exportType)
+    const exportTypes = this.getExportTypes()
+    const exportResult = exportTypes[this.state.exportType](enabledFields)
+    const tabs = []
+    for (let type in exportTypes) {
+      tabs.push((
+        <li key={type} className={this.state.exportType === type ? 'active' : ''}>
+          <a href='#' onClick={this.setExportType.bind(null, type)}>{type}</a>
+        </li>
+      ))
+    }
+
     return (
       <div>
         <ul className='nav nav-tabs'>
-          {this.exportTypes.map((type) => (
-            <li key={type.value} className={this.state.exportType === type.value ? 'active' : ''}>
-              <a href='#' onClick={this.setExportType.bind(null, type.value)}>{type.label}</a>
-            </li>
-          ))}
+          {tabs}
         </ul>
         <div className='well export-result'>{exportResult}</div>
       </div>
@@ -35,7 +44,27 @@ export default React.createClass({
     this.setState({exportType})
     event.preventDefault()
   },
-  exportSql: function (tableName, fields, client) {
+  exportJSONTableSchema: function (fields) {
+    const typeMap = {
+      float: 'number',
+      text: 'string'
+    }
+    return fields.map((field) => {
+      const jtsField = {
+        name: field.machineName,
+        type: typeMap[field.type] || field.type,
+        constraints: {
+          required: !field.nullable
+        }
+      }
+      if (field.type === 'string') {
+        jtsField.constraints.maxLength = field.type.maxLength
+      }
+      return JSON.stringify(jtsField, null, 2)
+    })
+  },
+  exportSql: function (client, fields) {
+    const tableName = this.props.file.name ? this.props.file.name.split('.')[0] : 'table_name'
     const knex = Knex({ client: client })
 
     const sql = knex.schema.createTable(tableName, function (table) {


### PR DESCRIPTION
This pull request adds support for exporting [JSON table schema](http://dataprotocols.org/json-table-schema/).

Requested in #2 and #4. @rgrp @harrisj how's this look? Supports `name`, `type`, `constraints.required` and `constraints.maxLength`. Need anything else?

Demo: http://csv-schema-test.surge.sh/
